### PR TITLE
Remove license-file from the manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "cfg_aliases"
 version = "0.1.0"
 license = "MIT"
-license-file = "LICENSE"
 authors = ["Zicklag <zicklag@katharostech.com>"]
 edition = "2018"
 description = "A tiny utility to help save you a lot of effort with long winded `#[cfg()]` checks."


### PR DESCRIPTION
Apparently, it's not expected, see https://searchfox.org/mozilla-central/rev/25d5a4443a7e13cfa58eff38f1faa5e69f0b170f/python/mozbuild/mozbuild/vendor/vendor_rust.py#377-392