### PR TITLE
Fix triggering `str_to_string` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ exclude = ["modoc.config", "release.toml"]
 
 [badges]
 maintenance = { status = "passively-maintained" }
+
+[lints.clippy]
+str_to_string = "deny"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ macro_rules! cfg_aliases {
                 "CARGO_CFG_{}",
                 &stringify!($cfgname).to_uppercase().replace("-", "_")
             )
-        ).unwrap_or("".to_string()).split(",").find(|x| x == &$cfgvalue).is_some()
+        ).unwrap_or("".to_owned()).split(",").find(|x| x == &$cfgvalue).is_some()
     };
 
     // Emitting `any(clause1,clause2,...)`: convert to `$crate::cfg_aliases!(clause1) && $crate::cfg_aliases!(clause2) && ...`

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,20 @@
+use cfg_aliases::cfg_aliases;
+
+#[test]
+fn basic_setup() {
+    // Same as in the docs.
+    // Note that tests build this already, but unfortunately this doesn't catch clippy lints!
+    // See https://github.com/rust-lang/rust/issues/56232
+    cfg_aliases! {
+        // Platforms
+        wasm: { target_arch = "wasm32" },
+        android: { target_os = "android" },
+        macos: { target_os = "macos" },
+        linux: { target_os = "linux" },
+        // Backends
+        surfman: { all(unix, feature = "surfman", not(wasm)) },
+        glutin: { all(feature = "glutin", not(wasm)) },
+        wgl: { all(windows, feature = "wgl", not(wasm)) },
+        dummy: { not(any(wasm, glutin, wgl, surfman)) },
+    };
+}


### PR DESCRIPTION
Over on https://github.com/rerun-io/rerun/ we have `str_to_string` enabled, thus tripping here.
Trivial fix + stand-alone test since unfortunately `clippy` doesn't run on tests