### PR TITLE
Fix not handling `debug_assertions` in cfg_aliases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,12 +175,18 @@
 macro_rules! cfg_aliases {
     // Helper that just checks whether the CFG environment variable is set
     (@cfg_is_set $cfgname:ident) => {
-        std::env::var(
-            format!(
-                "CARGO_CFG_{}",
-                &stringify!($cfgname).to_uppercase().replace("-", "_")
-            )
-        ).is_ok()
+        {
+            let cfg_var = stringify!($cfgname).to_uppercase().replace("-", "_");
+            let result = std::env::var(format!("CARGO_CFG_{}", &cfg_var)).is_ok();
+
+            // CARGO_CFG_DEBUG_ASSERTIONS _should_ be set for when debug assertions are enabled,
+            // but as of writing is not: see https://github.com/rust-lang/cargo/issues/5777
+            if !result && cfg_var == "DEBUG_ASSERTIONS" {
+                std::env::var("PROFILE") == Ok("debug".to_owned())
+            } else {
+                result
+            }
+        }
     };
     // Helper to check for the presense of a feature
     (@cfg_has_feature $feature:expr) => {


### PR DESCRIPTION
There's a pretty annoying bug in cargo where `CARGO_CFG_DEBUG_ASSERTIONS` is not set:
* https://github.com/rust-lang/cargo/issues/6148

Previously, I had to workaround this here: https://github.com/rerun-io/rerun/blob/ac75d50/crates/re_renderer/build.rs#L125

This PR fixes this at the source. Tested this change against `re_renderer` without above workaround and this makes it work :)